### PR TITLE
Convert birdweather uploads to flac

### DIFF
--- a/scripts/utils/reporting.py
+++ b/scripts/utils/reporting.py
@@ -6,6 +6,8 @@ import os
 import sqlite3
 import subprocess
 import tempfile
+import io
+import soundfile
 from time import sleep
 
 import requests
@@ -169,6 +171,16 @@ def bird_weather(file: ParseFileName, detections: [Detection]):
     if conf['BIRDWEATHER_ID'] == "":
         return
     if detections:
+        try:
+            data, samplerate = soundfile.read(file.file_name)
+            buf = io.BytesIO()
+            soundfile.write(buf, data, samplerate, format='FLAC')
+            flac_data = buf.getvalue()
+        except Exception as e:
+            log.error("Error during FLAC conversion: %s", e)
+            return
+        gzip_flac_data = gzip.compress(flac_data)
+
         # POST soundscape to server
         soundscape_url = (f'https://app.birdweather.com/api/v1/stations/'
                           f'{conf["BIRDWEATHER_ID"]}/soundscapes?timestamp={file.iso8601}')
@@ -177,7 +189,7 @@ def bird_weather(file: ParseFileName, detections: [Detection]):
             wav_data = f.read()
         gzip_wav_data = gzip.compress(wav_data)
         try:
-            response = requests.post(url=soundscape_url, data=gzip_wav_data, timeout=30,
+            response = requests.post(url=soundscape_url, data=gzip_flac_data, timeout=30,
                                      headers={'Content-Type': 'application/octet-stream', 'Content-Encoding': 'gzip'})
             log.info("Soundscape POST Response Status - %d", response.status_code)
             sdata = response.json()

--- a/scripts/utils/reporting.py
+++ b/scripts/utils/reporting.py
@@ -185,9 +185,6 @@ def bird_weather(file: ParseFileName, detections: [Detection]):
         soundscape_url = (f'https://app.birdweather.com/api/v1/stations/'
                           f'{conf["BIRDWEATHER_ID"]}/soundscapes?timestamp={file.iso8601}')
 
-        with open(file.file_name, 'rb') as f:
-            wav_data = f.read()
-        gzip_wav_data = gzip.compress(wav_data)
         try:
             response = requests.post(url=soundscape_url, data=gzip_flac_data, timeout=30,
                                      headers={'Content-Type': 'application/octet-stream', 'Content-Encoding': 'gzip'})


### PR DESCRIPTION
Fixes : https://github.com/Nachtzuster/BirdNET-Pi/issues/394

See discussion https://github.com/Nachtzuster/BirdNET-Pi/discussions/390

Align with new birdweather requirement. Uses a python method without intermediate data writing.

The implementation only impacts files that are uploaded - the recording is still done in wav, and the user can use whatever format they want such as mp3